### PR TITLE
feat: add new chart display options

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,13 @@ SVG width for line chart.
 
 SVG height for line chart.
 
+##### responsive
+
+- Type: `boolean`<br>
+- Default: `false`
+
+Whether the chart should be automatically resized to fit its container. If true, `width` and `height` options are used for the initial sizing/SVG viewBox size.
+
 ##### margin
 
 - Type: `Object`<br>
@@ -113,6 +120,41 @@ Width of line.
 - Default: `steelblue`
 
 Color of line.
+
+##### showXAxis
+
+- Type: `boolean`<br>
+- Default: `true`
+
+Whether to show the X axis.
+
+##### showYAxis
+
+- Type: `boolean`<br>
+- Default: `true`
+
+Whether to show the Y axis.
+
+##### showValues
+
+- Type: `boolean`<br>
+- Default: `true`
+
+Whether to show values above each point.
+
+##### showDots
+
+- Type: `boolean`
+- Default: `true`
+
+Whether to show dots at each point.
+
+##### dotAttrs
+
+- Type: `Object`<br>
+- Default: `{}`
+
+Attributes set on each dot element (only if `showDots` is `true`).
 
 ##### isCurve
 

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -16,5 +16,5 @@ function removeAllSpace (str) {
 
 test('line chart generator', () => {
   expect(line).toBeDefined()
-  expect(removeAllSpace(line({ data, d3node }))).toBe(removeAllSpace(result))
+  expect(removeAllSpace(line({ data, d3node, showDots: false, showValues: false }))).toBe(removeAllSpace(result))
 })

--- a/dist/index.js
+++ b/dist/index.js
@@ -20,12 +20,24 @@ function line() {
       _container = _ref$container === undefined ? '\n    <div id="container">\n      <h2>Line Chart</h2>\n      <div id="chart"></div>\n    </div>\n  ' : _ref$container,
       _ref$style = _ref.style,
       _style = _ref$style === undefined ? '' : _ref$style,
+      _ref$dotAttrs = _ref.dotAttrs,
+      _dotAttrs = _ref$dotAttrs === undefined ? {} : _ref$dotAttrs,
       _ref$width = _ref.width,
       _width = _ref$width === undefined ? 960 : _ref$width,
       _ref$height = _ref.height,
       _height = _ref$height === undefined ? 500 : _ref$height,
+      _ref$responsive = _ref.responsive,
+      _responsive = _ref$responsive === undefined ? false : _ref$responsive,
       _ref$margin = _ref.margin,
       _margin = _ref$margin === undefined ? { top: 20, right: 20, bottom: 20, left: 30 } : _ref$margin,
+      _ref$showXAxis = _ref.showXAxis,
+      _showXAxis = _ref$showXAxis === undefined ? true : _ref$showXAxis,
+      _ref$showYAxis = _ref.showYAxis,
+      _showYAxis = _ref$showYAxis === undefined ? true : _ref$showYAxis,
+      _ref$showDots = _ref.showDots,
+      _showDots = _ref$showDots === undefined ? true : _ref$showDots,
+      _ref$showValues = _ref.showValues,
+      _showValues = _ref$showValues === undefined ? true : _ref$showValues,
       _ref$lineWidth = _ref.lineWidth,
       _lineWidth = _ref$lineWidth === undefined ? 1.5 : _ref$lineWidth,
       _ref$lineColor = _ref.lineColor,
@@ -56,14 +68,20 @@ function line() {
     _div = document.createElement('div');
     _div.innerHTML = _container;
     _d3 = d3;
-    svg = _d3.select(_div).select('#chart').append('svg');
+    svg = _d3.select(_div).select(_selector).append('svg');
     addStyle(_style);
   }
 
   var width = _width - _margin.left - _margin.right;
   var height = _height - _margin.top - _margin.bottom;
 
-  var gWrap = svg.attr('width', _width).attr('height', _height).append('g').attr('transform', 'translate(' + _margin.left + ', ' + _margin.top + ')');
+  var gWrap = svg.append('g').attr('transform', 'translate(' + _margin.left + ', ' + _margin.top + ')');
+
+  if (_responsive) {
+    svg.attr('viewBox', '0 0 ' + _width + ' ' + _height).attr('preserveAspectRatio', 'xMinYMin');
+  } else {
+    svg.attr('width', _width).attr('height', _height);
+  }
 
   var g = gWrap.append('g');
 
@@ -85,16 +103,53 @@ function line() {
     return d.value;
   }));
 
-  g.append('g').attr('transform', 'translate(0, ' + height + ')').call(_d3.axisBottom(xScale));
+  if (_showXAxis) {
+    g.append('g').attr('transform', 'translate(0, ' + height + ')').call(_d3.axisBottom(xScale));
+  }
 
-  g.append('g').call(_d3.axisLeft(yScale));
+  if (_showYAxis) {
+    g.append('g').call(_d3.axisLeft(yScale));
+  }
 
   g.append('path').datum(data).attr('fill', 'none').attr('stroke', _lineColor).attr('stroke-width', _lineWidth).attr('d', lineChart);
+
+  if (_showDots) {
+    (function () {
+      var dotContainer = g.append('g');
+      dotContainer.selectAll('circle').data(data).enter().append('circle').classed('dot', true).attr('fill', _lineColor).attr('r', 4).attr('cx', function (d) {
+        return xScale(d.key);
+      }).attr('cy', function (d) {
+        return yScale(d.value);
+      });
+
+      var keys = Object.keys(_dotAttrs);
+
+      var _loop = function _loop(i) {
+        dotContainer.selectAll('.dot').attr(keys[i], function (d) {
+          return _dotAttrs[keys[i]](d.value);
+        });
+      };
+
+      for (var i = 0; i < keys.length; i++) {
+        _loop(i);
+      }
+    })();
+  }
+
+  if (_showValues) {
+    g.append('g').selectAll('text').data(data).enter().append('text').attr('class', 'dot-value-label').attr('text-anchor', 'middle').attr('x', function (d) {
+      return xScale(d.key);
+    }).attr('y', function (d) {
+      return yScale(d.value);
+    }).attr('dy', '-0.5em').attr('fill', 'currentColor').text(function (d) {
+      return d.value;
+    });
+  }
 
   var result = void 0;
   if (isNodeEnv()) {
     if (_export) result = d3n;else result = d3n.chartHTML();
-  } else result = _div.querySelector('#container').innerHTML;
+  } else result = _div.querySelector(_selector).parentNode.innerHTML;
 
   return result;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -14,9 +14,15 @@ const { addStyle } = require('./utils')
  * @param {string} selector DOM selector in container
  * @param {string} container DOM contained the visualization result
  * @param {string} style Line chart style
+ * @param {object} dotAttrs Line dot element attributes. Only used if showDots is true.
  * @param {number} width
  * @param {number} height
+ * @param {boolean} responsive Whether the chart should be automatically resized to fit its container. If true, width and height options are used for the initial sizing/SVG viewBox size.
  * @param {object} margin
+ * @param {boolean} showXAxis Whether to show the X axis
+ * @param {boolean} showYAxis Whether to show the Y axis
+ * @param {boolean} showValues Whether to show values above each point
+ * @param {boolean} showDots Whether to show dots at each point
  * @param {number} lineWidth
  * @param {string} lineColor
  * @param {boolean} isCurve Whether the line chart is curve
@@ -35,9 +41,15 @@ function line ({
     </div>
   `,
   style: _style = '',
+  dotAttrs: _dotAttrs = {},
   width: _width = 960,
   height: _height = 500,
+  responsive: _responsive = false,
   margin: _margin = { top: 20, right: 20, bottom: 20, left: 30 },
+  showXAxis: _showXAxis = true,
+  showYAxis: _showYAxis = true,
+  showDots: _showDots = true,
+  showValues: _showValues = true,
   lineWidth: _lineWidth = 1.5,
   lineColor: _lineColor = 'steelblue',
   isCurve: _isCurve = true,
@@ -64,17 +76,23 @@ function line ({
     _div = document.createElement('div')
     _div.innerHTML = _container
     _d3 = d3
-    svg = _d3.select(_div).select('#chart').append('svg')
+    svg = _d3.select(_div).select(_selector).append('svg')
     addStyle(_style) // Add style for line chart in browser
   }
 
   const width = _width - _margin.left - _margin.right
   const height = _height - _margin.top - _margin.bottom
 
-  const gWrap = svg.attr('width', _width)
-    .attr('height', _height)
-    .append('g')
+  const gWrap = svg.append('g')
     .attr('transform', `translate(${_margin.left}, ${_margin.top})`)
+
+  if (_responsive) {
+    svg.attr('viewBox', `0 0 ${_width} ${_height}`)
+      .attr('preserveAspectRatio', 'xMinYMin')
+  } else {
+    svg.attr('width', _width)
+      .attr('height', _height)
+  }
 
   const g = gWrap.append('g')
 
@@ -92,11 +110,17 @@ function line ({
   xScale.domain(_d3.extent(data, d => d.key))
   yScale.domain(_d3.extent(data, d => d.value))
 
-  g.append('g')
-    .attr('transform', `translate(0, ${height})`)
-    .call(_d3.axisBottom(xScale))
+  // Add the x axis
+  if (_showXAxis) {
+    g.append('g')
+      .attr('transform', `translate(0, ${height})`)
+      .call(_d3.axisBottom(xScale))
+  }
 
-  g.append('g').call(_d3.axisLeft(yScale))
+  // Add the y axis
+  if (_showYAxis) {
+    g.append('g').call(_d3.axisLeft(yScale))
+  }
 
   g.append('path')
     .datum(data)
@@ -105,11 +129,45 @@ function line ({
     .attr('stroke-width', _lineWidth)
     .attr('d', lineChart)
 
+  // Generate dots on each point.
+  if (_showDots) {
+    const dotContainer = g.append('g')
+    dotContainer.selectAll('circle')
+      .data(data)
+      .enter().append('circle')
+      .classed('dot', true)
+      .attr('fill', _lineColor)
+      .attr('r', 4)
+      .attr('cx', d => xScale(d.key))
+      .attr('cy', d => yScale(d.value))
+
+    const keys = Object.keys(_dotAttrs)
+    for (let i = 0; i < keys.length; i++) {
+      dotContainer.selectAll('.dot')
+        .attr(keys[i], d => _dotAttrs[keys[i]](d.value))
+    }
+  }
+
+  // Value labels on top of each point.
+  if (_showValues) {
+    g.append('g')
+      .selectAll('text')
+      .data(data)
+      .enter().append('text')
+      .attr('class', 'dot-value-label')
+      .attr('text-anchor', 'middle')
+      .attr('x', d => xScale(d.key))
+      .attr('y', d => yScale(d.value))
+      .attr('dy', '-0.5em')
+      .attr('fill', 'currentColor')
+      .text(d => d.value)
+  }
+
   let result
   if (isNodeEnv()) {
     if (_export) result = d3n
     else result = d3n.chartHTML()
-  } else result = _div.querySelector('#container').innerHTML
+  } else result = _div.querySelector(_selector).parentNode.innerHTML
 
   return result
 }


### PR DESCRIPTION
Similar to the additions in https://github.com/geekplux/markvis-bar/pull/1 (as well as those in https://github.com/geekplux/markvis-bar/pull/2 and https://github.com/geekplux/markvis-bar/pull/3):

Adds `responsive`, `showXAxis`, `showYAxis`, `showValues`, and a new `showDots` and `dotAttrs` (equivalent to the `barAttrs` in the markvis-bar PR). 

How this looks with `showDots`, `showValues`, and `isCurve` all set to `true`:

![image](https://user-images.githubusercontent.com/5589410/49112237-155fcd80-f247-11e8-8407-7b6393591d85.png)

And if `isCurve` is false:

![image](https://user-images.githubusercontent.com/5589410/49112284-33c5c900-f247-11e8-8634-d973a1d523bd.png)
